### PR TITLE
allow to set custom EHLO message

### DIFF
--- a/src/Mailer/SMTP.php
+++ b/src/Mailer/SMTP.php
@@ -47,6 +47,11 @@ class SMTP
     protected $secure;
 
     /**
+     * EHLO message
+     */
+    protected $ehlo;
+
+    /**
      * smtp username
      */
     protected $username;
@@ -101,6 +106,7 @@ class SMTP
         $this->host = $host;
         $this->port = $port;
         $this->secure = $secure;
+        if(!$this->ehlo) $this->ehlo = $host;
         $this->logger && $this->logger->addDebug("Set: the server");
         return $this;
     }
@@ -115,6 +121,16 @@ class SMTP
         $this->username = $username;
         $this->password = $password;
         $this->logger && $this->logger->addDebug("Set: the auth");
+        return $this;
+    }
+
+    /**
+     * set the EHLO message
+     * @param $ehlo
+     * @return $this
+     */
+    public function setEhlo($ehlo){
+        $this->ehlo = $ehlo;
         return $this;
     }
 
@@ -195,7 +211,7 @@ class SMTP
      * @throws SMTPException
      */
     protected function ehlo(){
-        $in = "EHLO " . $this->host . $this->CRLF;
+        $in = "EHLO " . $this->ehlo . $this->CRLF;
         $code = $this->pushStack($in);
         if ($code !== '250'){
             throw new CodeException('250', $code, array_pop($this->resultStack));


### PR DESCRIPTION
some MTAs will reject mails with an obviously bogus EHLO message.
Sending the MTAs own host name is one of the rejected cases. This patch
allows users to set their own value for EHLO if needed. Default is still
the server host.