### PR TITLE
Mailtrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+sudo: false
+php:
+  - "5.6"
+  - "5.5"
+  - "5.4"
+  - "5.3"
+  - "hhvm"
+  - "nightly"
+install: composer update
+script: ./vendor/bin/phpunit --verbose

--- a/tests/MailerTest.php
+++ b/tests/MailerTest.php
@@ -31,6 +31,7 @@ class MailerTest extends TestCase {
 
         $status = $this->smtp->send($this->message);
         $this->assertTrue($status);
+        usleep(self::DELAY);
     }
 
     public function testSend(){
@@ -45,6 +46,7 @@ class MailerTest extends TestCase {
             ->addAttachment('host', '/etc/hosts')
             ->send();
         $this->assertTrue($status);
+        usleep(self::DELAY);
     }
 
 }

--- a/tests/MailerTest.php
+++ b/tests/MailerTest.php
@@ -18,8 +18,8 @@ class MailerTest extends TestCase {
 
     public function testSMTP(){
         $this->smtp
-            ->setServer('smtp.ym.163.com', 25)
-            ->setAuth('bot@ym.txthinking.com', ''); // email, password
+            ->setServer(self::SERVER, self::PORT)
+            ->setAuth(self::USER, self::PASS); // email, password
 
         $this->message
             ->setFrom('Tom', 'bot@ym.txthinking.com') // your name, your email
@@ -35,8 +35,8 @@ class MailerTest extends TestCase {
 
     public function testSend(){
         $status = (new Mailer(new Logger('Mailer')))
-            ->setServer('smtp.ym.163.com', 25)
-            ->setAuth('bot@ym.txthinking.com', '') // email, password
+            ->setServer(self::SERVER, self::PORT)
+            ->setAuth(self::USER, self::PASS) // email, password
             ->setFrom('Tom', 'bot@ym.txthinking.com') // your name, your email
             ->setFakeFrom('张全蛋', 'zhangquandan@hello.com') // a fake name, a fake email
             ->addTo('Cloud', 'cloud@txthinking.com')

--- a/tests/SMTPTest.php
+++ b/tests/SMTPTest.php
@@ -75,7 +75,7 @@ class SMTPTest extends TestCase {
      */
     public function testConnectSMTPException()
     {
-        $this->smtp->setServer(self::SERVER, "99999", null)
+        $this->smtp->setServer('localhost', "99999", null)
             ->setAuth('none', 'none');
         $message = new Message();
         $message->setFrom('You', 'nobody@nowhere.no')

--- a/tests/SMTPTest.php
+++ b/tests/SMTPTest.php
@@ -38,7 +38,7 @@ class SMTPTest extends TestCase {
 
     public function testSetServer()
     {
-        $result = $this->smtp->setServer("localhost", "25", null);
+        $result = $this->smtp->setServer('localhost', '25', null);
         $this->assertEquals('localhost', $this->testHelper->getPropertyValue($this->smtp, 'host'));
         $this->assertEquals('25', $this->testHelper->getPropertyValue($this->smtp, 'port'));
         $this->assertSame($this->smtp, $result);
@@ -55,8 +55,8 @@ class SMTPTest extends TestCase {
 
     public function testMessage()
     {
-        $this->smtp->setServer("localhost", "25", null)
-            ->setAuth('none', 'none');
+        $this->smtp->setServer(self::SERVER, self::PORT, null)
+            ->setAuth(self::USER, self::PASS);
 
         $message = new Message();
         $message->setFrom('You', 'nobody@nowhere.no')
@@ -74,7 +74,7 @@ class SMTPTest extends TestCase {
      */
     public function testConnectSMTPException()
     {
-        $this->smtp->setServer("localhost", "99999", null)
+        $this->smtp->setServer(self::SERVER, "99999", null)
             ->setAuth('none', 'none');
         $message = new Message();
         $message->setFrom('You', 'nobody@nowhere.no')

--- a/tests/SMTPTest.php
+++ b/tests/SMTPTest.php
@@ -66,6 +66,7 @@ class SMTPTest extends TestCase {
 
         $status = $this->smtp->send($message);
         $this->assertTrue($status);
+        usleep(self::DELAY);
     }
 
 
@@ -83,7 +84,6 @@ class SMTPTest extends TestCase {
             ->setBody('This is a test part two');
 
         $this->smtp->send($message);
-
     }
 
 

--- a/tests/SMTPTest.php
+++ b/tests/SMTPTest.php
@@ -29,11 +29,19 @@ class SMTPTest extends TestCase {
      */
     protected $testHelper;
 
+    /** @var  Message */
+    protected $message;
+
+
     public function setup()
     {
         $this->smtp = new SMTP();
         $this->testHelper = new TestHelper();
-
+        $this->message = new Message();
+        $this->message->setFrom('You', 'nobody@nowhere.no')
+                ->setTo('Them', 'them@nowhere.no')
+                ->setSubject('This is a test')
+                ->setBody('This is a test part two');
     }
 
     public function testSetServer()
@@ -58,17 +66,20 @@ class SMTPTest extends TestCase {
         $this->smtp->setServer(self::SERVER, self::PORT, null)
             ->setAuth(self::USER, self::PASS);
 
-        $message = new Message();
-        $message->setFrom('You', 'nobody@nowhere.no')
-            ->setTo('Them', 'them@nowhere.no')
-            ->setSubject('This is a test')
-            ->setBody('This is a test part two');
-
-        $status = $this->smtp->send($message);
+        $status = $this->smtp->send($this->message);
         $this->assertTrue($status);
         usleep(self::DELAY);
     }
 
+    public function testTLSMessage()
+    {
+        $this->smtp->setServer(self::SERVER, self::PORT_TLS, 'tls')
+                   ->setAuth(self::USER, self::PASS);
+
+        $status = $this->smtp->send($this->message);
+        $this->assertTrue($status);
+        usleep(self::DELAY);
+    }
 
     /**
      * @expectedException \Tx\Mailer\Exceptions\SMTPException

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,20 @@
 <?php
-// someday if you want do init action before testing
+
+/**
+ * Configures the SMTP server used for testing
+ */
 class TestCase extends \PHPUnit_Framework_TestCase{
+    /** SMTP server to test against */
+    const SERVER = 'mailtrap.io';
+    /** plain text port */
+    const PORT = 25;
+    /** TLS port */
+    const PORT_TLS = 25;
+    /** SSL port (not supported by mailtrap currently */
+    const PORT_SSL = 25;
+    /** user for LOGIN auth */
+    const USER = '4139926c57fd07bf5';
+    /** password for LOGIN auth */
+    const PASS = '1b214cf5f3874c';
 }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,5 +16,7 @@ class TestCase extends \PHPUnit_Framework_TestCase{
     const USER = '4139926c57fd07bf5';
     /** password for LOGIN auth */
     const PASS = '1b214cf5f3874c';
+    /** delay in microsends between SMTP tests to avoid API limits (we're allowed two messages/second) */
+    const DELAY = 500000; // half a second
 }
 


### PR DESCRIPTION
This PR changes the tests to make use of a free account at mailtrap.io. This allows everyone to easily run the tests without any additional local setup. I added a travis config for setting up automated tests at travis-ci.org (you should set it up there after merging). I also added a test to be run via TLS (unfortunately mailtrap has no SSL version to test that as well).

Feel free to create your own mailtrap account and replace the user/password.

Additional tests could use the PHP imap extension to actually check that mails arrived as they should via the POP3 access mailtrap.io provides.