### PR TITLE
feat(tls): expand tls options

### DIFF
--- a/tests/SMTPTest.php
+++ b/tests/SMTPTest.php
@@ -85,6 +85,36 @@ class SMTPTest extends TestCase
         usleep(self::DELAY);
     }
 
+    public function testTLSv10Message()
+    {
+        $this->smtp->setServer(self::SERVER, self::PORT, 'tlsv1.0')
+                   ->setAuth(self::USER, self::PASS);
+
+        $status = $this->smtp->send($this->message);
+        $this->assertTrue($status);
+        usleep(self::DELAY);
+    }
+
+    public function testTLSv11Message()
+    {
+        $this->smtp->setServer(self::SERVER, self::PORT, 'tlsv1.1')
+                   ->setAuth(self::USER, self::PASS);
+
+        $status = $this->smtp->send($this->message);
+        $this->assertTrue($status);
+        usleep(self::DELAY);
+    }
+
+    public function testTLSv12Message()
+    {
+        $this->smtp->setServer(self::SERVER, self::PORT, 'tlsv1.2')
+                   ->setAuth(self::USER, self::PASS);
+
+        $status = $this->smtp->send($this->message);
+        $this->assertTrue($status);
+        usleep(self::DELAY);
+    }
+
     /**
      * @expectedException \Tx\Mailer\Exceptions\SMTPException
      */


### PR DESCRIPTION
SparkPost recently deprecated TLS v1.0 on their end (seems to be a global trend
in regard to PCI compliance) and as a user of both this lib and SparkPost, I was
kinda screwed. I monkey patched things on my end to make sure my site was
working, and this commit expands upon things / future proof them a bit.

Since the TLS 1.0, 1.1 and 1.2 constants are PHP 5.6+, I added a sanity check
for that while preserving the original functionality.

I added some tests for the new scenarios but the testing suite was throwing a
ton of "Could not open SMTP port" errors, even before I had made any code
changes. Rolling the dice since I wasn't able to fully test against the test
suite.