### PR TITLE
TLS handling change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: php
 sudo: false
 php:
+  - "7.4"
+  - "7.3"
+  - "7.2"
+  - "7.1"
   - "7.0"
   - "5.6"
-  - "nightly"
 install: composer update
 script: ./vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~5.0",
         "monolog/monolog": "~1.13"
     },
     "autoload": {

--- a/src/Mailer/SMTP.php
+++ b/src/Mailer/SMTP.php
@@ -241,7 +241,9 @@ class SMTP
                 $crypto_type = STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
                 break;
             default:
-                $crypto_type = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+                $crypto_type = STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT |
+                               STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT |
+                               STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
                 break;
         }
 


### PR DESCRIPTION
As mentioned in https://www.php.net/manual/en/function.stream-socket-enable-crypto.php#119122    `STREAM_CRYPTO_METHOD_TLS_CLIENT` no longer means any protocol, but defaults to the (outdated) TLS 1.0 only.

Since some servers will reject connections with TLS 1.0 for security reasons this causes trouble. Eg: https://github.com/splitbrain/dokuwiki-plugin-smtp/issues/31

This patch explicitly allows all three protocol versions when 'tls' is provided.

This also updates phpunit to 5.0 because the old 4.0 caused errors on modern PHP.