### PR TITLE
fix: Fix Message-ID format to comply with RFC 5322

### DIFF
--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -358,7 +358,7 @@ class Message
         }
         $this->header['Subject'] = $subject;
 
-        $this->header['Message-ID'] = '<' . md5(uniqid()) . '@' . $this->fromEmail . '>';
+        $this->header['Message-ID'] = '<' . md5(uniqid()) . $this->fromEmail . '>';
         $this->header['X-Priority'] = '3';
         $this->header['X-Mailer'] = 'Mailer (https://github.com/txthinking/Mailer)';
         $this->header['MIME-Version'] = '1.0';


### PR DESCRIPTION
fix: Fix Message-ID format to comply with RFC 5322

The original format of the Message-ID contained two '@' symbols, which caused it to be invalid according to RFC 5322. The updated Message-ID format now follows the correct pattern: 
<unique-id@domain>, ensuring that the domain part contains only one '@' symbol and the Message-ID remains unique.

This fix ensures that the email system can correctly parse the Message-ID.