### PR TITLE
accept any psr/log version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "psr/log": "~1.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.5",


### PR DESCRIPTION
Since this library only consumes loggers, but does not implement any loggers, it's safe to accept all three versions of psr/log making the library more compatible with different environments.

See also https://www.php-fig.org/blog/2019/10/upgrading-psr-interfaces/